### PR TITLE
Add encounter probability panel to explore UI

### DIFF
--- a/client/src/desktop/overlays/Explore.tsx
+++ b/client/src/desktop/overlays/Explore.tsx
@@ -2,6 +2,7 @@ import { useGameDirector } from '@/desktop/contexts/GameDirector';
 import { useGameStore } from '@/stores/gameStore';
 import { useMarketStore } from '@/stores/marketStore';
 import { streamIds } from '@/utils/cloudflare';
+import { EXPLORE_PROBABILITY_COUNTS, getExploreEncounterProbabilities } from '@/utils/explore';
 import { getEventTitle } from '@/utils/events';
 import { ItemUtils } from '@/utils/loot';
 import { Box, Button, Typography } from '@mui/material';
@@ -68,6 +69,7 @@ export default function ExploreOverlay() {
   };
 
   const event = exploreLog[0];
+  const encounterProbabilities = getExploreEncounterProbabilities();
 
   return (
     <Box sx={[styles.container, spectating && styles.spectating]}>
@@ -156,6 +158,30 @@ export default function ExploreOverlay() {
               )}
             </Box>
           </Box>}
+        </Box>
+        <Box sx={styles.probabilitiesContainer}>
+          <Typography sx={styles.probabilitiesTitle}>Encounter Chances</Typography>
+          <Box sx={styles.probabilityRow}>
+            <Typography sx={styles.probabilityLabel}>Beast</Typography>
+            <Typography sx={styles.probabilityValue}>
+              {encounterProbabilities.beast.toFixed(1)}%
+            </Typography>
+          </Box>
+          <Box sx={styles.probabilityRow}>
+            <Typography sx={styles.probabilityLabel}>Obstacle</Typography>
+            <Typography sx={styles.probabilityValue}>
+              {encounterProbabilities.obstacle.toFixed(1)}%
+            </Typography>
+          </Box>
+          <Box sx={styles.probabilityRow}>
+            <Typography sx={styles.probabilityLabel}>Discovery</Typography>
+            <Typography sx={styles.probabilityValue}>
+              {encounterProbabilities.discovery.toFixed(1)}%
+            </Typography>
+          </Box>
+          <Typography sx={styles.probabilitiesFootnote}>
+            Based on {EXPLORE_PROBABILITY_COUNTS.total} entropy outcomes (seed % 3).
+          </Typography>
         </Box>
       </Box>
 
@@ -308,6 +334,42 @@ const styles = {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  probabilitiesContainer: {
+    marginTop: '12px',
+    padding: '10px 12px',
+    borderRadius: '10px',
+    border: '1px solid rgba(128, 255, 0, 0.15)',
+    background: 'rgba(8, 62, 34, 0.35)',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '6px',
+  },
+  probabilitiesTitle: {
+    fontFamily: 'Cinzel, Georgia, serif',
+    fontWeight: 600,
+    fontSize: '0.9rem',
+    color: '#d0c98d',
+    letterSpacing: '0.5px',
+    textTransform: 'uppercase',
+  },
+  probabilityRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  probabilityLabel: {
+    fontSize: '0.85rem',
+    color: '#d0c98d',
+  },
+  probabilityValue: {
+    fontSize: '0.85rem',
+    fontWeight: 600,
+    color: '#80ff00',
+  },
+  probabilitiesFootnote: {
+    fontSize: '0.7rem',
+    color: 'rgba(208, 201, 141, 0.7)',
   },
   eventLogText: {
     color: '#d0c98d',

--- a/client/src/mobile/containers/ExploreScreen.tsx
+++ b/client/src/mobile/containers/ExploreScreen.tsx
@@ -1,6 +1,7 @@
 import { useGameDirector } from '@/mobile/contexts/GameDirector';
 import { useGameStore } from '@/stores/gameStore';
 import { getEventIcon, getEventTitle } from '@/utils/events';
+import { EXPLORE_PROBABILITY_COUNTS, getExploreEncounterProbabilities } from '@/utils/explore';
 import { Box, Button, Typography, keyframes } from '@mui/material';
 import { useEffect, useRef, useState } from 'react';
 import AdventurerInfo from '../components/AdventurerInfo';
@@ -15,6 +16,7 @@ export default function ExploreScreen() {
   const [untilBeast, setUntilBeast] = useState(false);
   const [isExploring, setIsExploring] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
+  const encounterProbabilities = getExploreEncounterProbabilities();
 
   // Function to scroll to top
   const scrollToTop = () => {
@@ -47,6 +49,31 @@ export default function ExploreScreen() {
         <Box sx={styles.section}>
           <Box sx={styles.sectionHeader}>
             <Typography sx={styles.sectionTitle}>Explorer Log</Typography>
+          </Box>
+
+          <Box sx={styles.probabilityCard}>
+            <Typography sx={styles.probabilityTitle}>Encounter Chances</Typography>
+            <Box sx={styles.probabilityRow}>
+              <Typography sx={styles.probabilityLabel}>Beast</Typography>
+              <Typography sx={styles.probabilityValue}>
+                {encounterProbabilities.beast.toFixed(1)}%
+              </Typography>
+            </Box>
+            <Box sx={styles.probabilityRow}>
+              <Typography sx={styles.probabilityLabel}>Obstacle</Typography>
+              <Typography sx={styles.probabilityValue}>
+                {encounterProbabilities.obstacle.toFixed(1)}%
+              </Typography>
+            </Box>
+            <Box sx={styles.probabilityRow}>
+              <Typography sx={styles.probabilityLabel}>Discovery</Typography>
+              <Typography sx={styles.probabilityValue}>
+                {encounterProbabilities.discovery.toFixed(1)}%
+              </Typography>
+            </Box>
+            <Typography sx={styles.probabilityFootnote}>
+              Based on {EXPLORE_PROBABILITY_COUNTS.total} entropy outcomes (seed % 3).
+            </Typography>
           </Box>
 
           <Box sx={styles.encountersList} ref={listRef}>
@@ -268,6 +295,42 @@ const styles = {
     background: 'rgba(128, 255, 0, 0.05)',
     borderRadius: '6px',
     border: '1px solid rgba(128, 255, 0, 0.1)',
+  },
+  probabilityCard: {
+    padding: '12px',
+    borderRadius: '16px',
+    border: '1px solid rgba(128, 255, 0, 0.2)',
+    background: 'rgba(8, 62, 34, 0.35)',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    mb: 2,
+  },
+  probabilityTitle: {
+    color: '#d0c98d',
+    fontFamily: 'Cinzel, Georgia, serif',
+    fontWeight: 600,
+    fontSize: '1rem',
+    letterSpacing: '0.75px',
+    textTransform: 'uppercase',
+  },
+  probabilityRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  probabilityLabel: {
+    fontSize: '0.95rem',
+    color: '#d0c98d',
+  },
+  probabilityValue: {
+    fontSize: '0.95rem',
+    fontWeight: 600,
+    color: '#80ff00',
+  },
+  probabilityFootnote: {
+    fontSize: '0.75rem',
+    color: 'rgba(208, 201, 141, 0.7)',
   },
   sectionHeader: {
     display: 'flex',

--- a/client/src/utils/explore.ts
+++ b/client/src/utils/explore.ts
@@ -1,0 +1,29 @@
+export interface ExploreEncounterProbabilities {
+  /** Percentage chance of encountering a beast when exploring. */
+  beast: number;
+  /** Percentage chance of encountering an obstacle when exploring. */
+  obstacle: number;
+  /** Percentage chance of finding a discovery/bonus when exploring. */
+  discovery: number;
+}
+
+export const EXPLORE_PROBABILITY_COUNTS = {
+  beast: 86,
+  obstacle: 85,
+  discovery: 85,
+  total: 256,
+} as const;
+
+/**
+ * Loot Survivor uses a u8 for explore entropy, so there are 256 possible values.
+ * The explore system chooses the encounter type via `seed % 3`, which makes
+ * remainder `0` a beast, `1` an obstacle, and `2` a discovery/bonus. Because
+ * 256 is not divisible by 3, beasts have one extra outcome in the cycle.
+ */
+export const getExploreEncounterProbabilities = (): ExploreEncounterProbabilities => {
+  return {
+    beast: (EXPLORE_PROBABILITY_COUNTS.beast / EXPLORE_PROBABILITY_COUNTS.total) * 100,
+    obstacle: (EXPLORE_PROBABILITY_COUNTS.obstacle / EXPLORE_PROBABILITY_COUNTS.total) * 100,
+    discovery: (EXPLORE_PROBABILITY_COUNTS.discovery / EXPLORE_PROBABILITY_COUNTS.total) * 100,
+  };
+};


### PR DESCRIPTION
## Summary
- add an explore utility that mirrors the contract entropy split to calculate encounter probabilities
- surface encounter chance readouts on the desktop and mobile explore overlays so players see beast, obstacle, and discovery odds

## Testing
- pnpm lint *(fails: missing @eslint/js in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b07f426c8325b8f94f93fc1940d2